### PR TITLE
[v1.3.3] Add support for Edit Status and Edit Document

### DIFF
--- a/src/main/java/seedu/pivot/commons/core/DeveloperMessages.java
+++ b/src/main/java/seedu/pivot/commons/core/DeveloperMessages.java
@@ -10,4 +10,5 @@ public class DeveloperMessages {
     public static final String ASSERT_MAIN_PAGE = "Program should be at case page";
     public static final String ASSERT_VALID_INDEX = "Index should be valid";
     public static final String ASSERT_FILE_EXIST = "File should exist";
+    public static final String ASSERT_REFERENCE_VALID = "Reference should be valid";
 }

--- a/src/main/java/seedu/pivot/commons/core/UserMessages.java
+++ b/src/main/java/seedu/pivot/commons/core/UserMessages.java
@@ -8,6 +8,7 @@ public class UserMessages {
     // Common messages
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_MISSING_PREFIX_INVALID_COMMAND = "Please specify a field to change! \n%1$s";
 
     // Main page messages
     public static final String MESSAGE_INVALID_CASE_DISPLAYED_INDEX = "The case index provided is invalid";

--- a/src/main/java/seedu/pivot/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/EditCommand.java
@@ -36,11 +36,11 @@ public abstract class EditCommand extends Command {
             + "Parameters: [s:STATUS]\n"
             + "Example: " + COMMAND_WORD + " status s:closed\n\n"
             + "TYPE 'doc'\n"
-            + "Parameters: [n:NAME] [r:REFERENCE]\n"
-            + "Example: " + COMMAND_WORD + " doc n:meeting notes\n\n"
+            + "Parameters: INDEX [n:NAME] [r:REFERENCE]\n"
+            + "Example: " + COMMAND_WORD + " doc 1 n:meeting notes\n\n"
             + "TYPE 'suspect','victim','witness'\n"
-            + "Parameters: [n:NAME] [g:GENDER] [p:PHONE] [e:EMAIL] [a:ADDRESS]\n"
-            + "Example: " + COMMAND_WORD + " suspect e:newEmail.com a:new road crescent\n\n";
+            + "Parameters: INDEX [n:NAME] [g:GENDER] [p:PHONE] [e:EMAIL] [a:ADDRESS]\n"
+            + "Example: " + COMMAND_WORD + " suspect 2 e:newEmail.com a:new road crescent\n\n";
 
 
     //public static final String MESSAGE_EDIT_CASE_SUCCESS = "Edited Case: %1$s";

--- a/src/main/java/seedu/pivot/logic/commands/OpenCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/OpenCommand.java
@@ -9,14 +9,17 @@ public abstract class OpenCommand extends Command {
 
     public static final String COMMAND_WORD = "open";
 
-    // TODO: to be updated when with open doc functionality
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Opens the item of a specified type, identified by the index number"
             + " used in the displayed list.\n"
             + "Format: '" + COMMAND_WORD + " TYPE'\n\n"
             + "TYPE 'case'\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " case 1";;
+            + "Parameters: INDEX\n"
+            + "Example: " + COMMAND_WORD + " case 1\n\n"
+            + "TYPE 'doc'\n"
+            + "Parameters: INDEX\n"
+            + "Example: " + COMMAND_WORD + " doc 1\n\n";
+
 
     protected final Index targetIndex;
 

--- a/src/main/java/seedu/pivot/logic/commands/casecommands/EditStatusCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/casecommands/EditStatusCommand.java
@@ -66,6 +66,7 @@ public class EditStatusCommand extends EditCommand {
                 stateCase.getDocuments(), stateCase.getSuspects(), stateCase.getVictims(), stateCase.getWitnesses(),
                 stateCase.getTags());
         model.setCase(stateCase, updatedCase);
+        model.commitPivot(String.format(MESSAGE_EDIT_STATUS_SUCCESS, status));
 
         return new CommandResult(String.format(MESSAGE_EDIT_STATUS_SUCCESS, status));
     }

--- a/src/main/java/seedu/pivot/logic/commands/casecommands/EditStatusCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/casecommands/EditStatusCommand.java
@@ -1,0 +1,72 @@
+package seedu.pivot.logic.commands.casecommands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_CASE_PAGE;
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_VALID_INDEX;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.pivot.commons.core.LogsCenter;
+import seedu.pivot.commons.core.index.Index;
+import seedu.pivot.logic.commands.CommandResult;
+import seedu.pivot.logic.commands.EditCommand;
+import seedu.pivot.logic.commands.exceptions.CommandException;
+import seedu.pivot.logic.state.StateManager;
+import seedu.pivot.model.Model;
+import seedu.pivot.model.investigationcase.Case;
+import seedu.pivot.model.investigationcase.Status;
+
+/**
+ * Edits the { @code Status } to an opened { @case Case } in PIVOT.
+ */
+public class EditStatusCommand extends EditCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " " + TYPE_STATUS
+            + ": Edits the status of the opened case.\n"
+            + "Parameters: "
+            + PREFIX_STATUS + "STATUS\n"
+            + "Example: " + COMMAND_WORD + " " + TYPE_STATUS + " "
+            + PREFIX_STATUS + "closed";
+
+    public static final String MESSAGE_EDIT_STATUS_SUCCESS = "Status updated: %1$s";
+    private static final Logger logger = LogsCenter.getLogger(EditStatusCommand.class);
+
+    private final Index index;
+    private final Status status;
+
+    /**
+     * Creates an EditStatusCommand to update the specified { @code Status } for a { @code Case }.
+     *
+     * @param index Index of the Case in PIVOT.
+     * @param status Status to be updated.
+     */
+    public EditStatusCommand(Index index, Status status) {
+        requireNonNull(index);
+        requireNonNull(status);
+        this.index = index;
+        this.status = status;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        logger.info("Updating status to current case...");
+        requireNonNull(model);
+        List<Case> lastShownList = model.getFilteredCaseList();
+
+        //check for valid index
+        assert(StateManager.atCasePage()) : ASSERT_CASE_PAGE;
+        assert(index.getZeroBased() < lastShownList.size()) : ASSERT_VALID_INDEX;
+
+        Case stateCase = lastShownList.get(index.getZeroBased());
+
+        // create new updated case
+        Case updatedCase = new Case(stateCase.getTitle(), stateCase.getDescription(), status,
+                stateCase.getDocuments(), stateCase.getSuspects(), stateCase.getVictims(), stateCase.getWitnesses(),
+                stateCase.getTags());
+        model.setCase(stateCase, updatedCase);
+
+        return new CommandResult(String.format(MESSAGE_EDIT_STATUS_SUCCESS, status));
+    }
+}

--- a/src/main/java/seedu/pivot/logic/commands/casecommands/EditTitleCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/casecommands/EditTitleCommand.java
@@ -65,6 +65,7 @@ public class EditTitleCommand extends EditCommand {
                 stateCase.getDocuments(), stateCase.getSuspects(), stateCase.getVictims(), stateCase.getWitnesses(),
                 stateCase.getTags());
         model.setCase(stateCase, updatedCase);
+        model.commitPivot(String.format(MESSAGE_EDIT_TITLE_SUCCESS, title));
 
         return new CommandResult(String.format(MESSAGE_EDIT_TITLE_SUCCESS, title));
     }

--- a/src/main/java/seedu/pivot/logic/commands/casecommands/EditTitleCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/casecommands/EditTitleCommand.java
@@ -36,7 +36,7 @@ public class EditTitleCommand extends EditCommand {
     private final Title title;
 
     /**
-     * Creates an EditTitleCommand to update the specified { @code Title } to a { @code Case }.
+     * Creates an EditTitleCommand to update the specified { @code Title } for a { @code Case }.
      *
      * @param index Index of the Case in PIVOT.
      * @param title Title to be updated.

--- a/src/main/java/seedu/pivot/logic/commands/casecommands/OpenCaseCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/casecommands/OpenCaseCommand.java
@@ -22,6 +22,12 @@ public class OpenCaseCommand extends OpenCommand {
 
     public static final String MESSAGE_OPEN_CASE_SUCCESS = "Opened Case: %1$s";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Opens the case at specified index in the current list\n"
+            + "TYPE 'case'\n"
+            + "Parameters: INDEX\n"
+            + "Example: " + COMMAND_WORD + " case 1\n\n";
+
     private static final Logger logger = LogsCenter.getLogger(OpenCaseCommand.class);
 
     /**

--- a/src/main/java/seedu/pivot/logic/commands/documentcommands/EditDocumentCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/documentcommands/EditDocumentCommand.java
@@ -1,0 +1,108 @@
+package seedu.pivot.logic.commands.documentcommands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_CASE_PAGE;
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_VALID_INDEX;
+import static seedu.pivot.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_REFERENCE;
+import static seedu.pivot.model.Model.PREDICATE_SHOW_ALL_CASES;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.pivot.commons.core.LogsCenter;
+import seedu.pivot.commons.core.UserMessages;
+import seedu.pivot.commons.core.index.Index;
+import seedu.pivot.logic.commands.CommandResult;
+import seedu.pivot.logic.commands.EditCommand;
+import seedu.pivot.logic.commands.exceptions.CommandException;
+import seedu.pivot.logic.state.StateManager;
+import seedu.pivot.model.Model;
+import seedu.pivot.model.investigationcase.Case;
+import seedu.pivot.model.investigationcase.Document;
+import seedu.pivot.model.investigationcase.Reference;
+import seedu.pivot.model.investigationcase.caseperson.Name;
+
+public class EditDocumentCommand extends EditCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " " + TYPE_DOC
+            + ": Edits the document of the opened case at the specified index.\n"
+            + "Parameters: "
+            + "INDEX "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_REFERENCE + "REFERENCE]\n"
+            + "Example: " + COMMAND_WORD + " " + TYPE_DOC + " " + "1" + " "
+            + PREFIX_NAME + "new name "
+            + PREFIX_REFERENCE + "edited.txt";
+
+
+    public static final String MESSAGE_EDIT_DOCUMENT_SUCCESS = "Edited document: %1$s";
+    private static final Logger logger = LogsCenter.getLogger(EditDocumentCommand.class);
+
+    private final Index index;
+    private final Index documentIndex;
+    private final Optional<Name> name;
+    private final Optional<Reference> reference;
+
+
+    /**
+     * Creates an EditDocumentCommand to edit a {@code Document} at index @code docIndex} with the
+     * name and reference if present, from the case at index {@code caseIndex}.
+     *
+     * @param caseIndex index of a case in the list.
+     * @param docIndex document index in the document list.
+     * @param name an {@code Optional<Name>} to update the document.
+     * @param reference an {@code Optional<Reference>} to update the document.
+     */
+    public EditDocumentCommand(Index caseIndex, Index docIndex, Optional<Name> name, Optional<Reference> reference) {
+        requireAllNonNull(caseIndex, docIndex, name, reference);
+        this.index = caseIndex;
+        this.documentIndex = docIndex;
+        this.name = name;
+        this.reference = reference;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        logger.info("Editing document of current case...");
+        requireNonNull(model);
+
+        List<Case> lastShownList = model.getFilteredCaseList();
+
+        //check for valid index
+        assert(StateManager.atCasePage()) : ASSERT_CASE_PAGE;
+        assert(index.getZeroBased() < lastShownList.size()) : ASSERT_VALID_INDEX;
+
+        //get current case in state
+        Case stateCase = lastShownList.get(index.getZeroBased());
+        List<Document> documents = stateCase.getDocuments();
+
+        //document index validation in model
+        if (documentIndex.getZeroBased() >= documents.size()) {
+            logger.info("Invalid index: " + documentIndex.getOneBased());
+            throw new CommandException(UserMessages.MESSAGE_INVALID_DOCUMENT_DISPLAYED_INDEX);
+        }
+
+        //get document
+        Document documentToEdit = documents.get(documentIndex.getZeroBased());
+
+        //edit document in case
+        Document editedDocument =
+                new Document(name.orElse(documentToEdit.getName()), reference.orElse(documentToEdit.getReference()));
+
+        documents.set(documentIndex.getZeroBased(), editedDocument);
+
+        Case updatedCase = new Case(stateCase.getTitle(), stateCase.getDescription(),
+                stateCase.getStatus(), documents, stateCase.getSuspects(),
+                stateCase.getVictims(), stateCase.getWitnesses(), stateCase.getTags());
+
+        //update model
+        model.setCase(stateCase, updatedCase);
+        model.commitPivot(String.format(MESSAGE_EDIT_DOCUMENT_SUCCESS, editedDocument));
+        model.updateFilteredCaseList(PREDICATE_SHOW_ALL_CASES);
+
+        return new CommandResult(String.format(MESSAGE_EDIT_DOCUMENT_SUCCESS, editedDocument));
+    }
+}

--- a/src/main/java/seedu/pivot/logic/commands/documentcommands/OpenDocumentCommand.java
+++ b/src/main/java/seedu/pivot/logic/commands/documentcommands/OpenDocumentCommand.java
@@ -24,6 +24,7 @@ import seedu.pivot.model.investigationcase.Reference;
 public class OpenDocumentCommand extends OpenCommand {
 
     public static final String MESSAGE_OPEN_DOCUMENT_SUCCESS = "Opened Document: %1$s";
+
     private static final Logger logger = LogsCenter.getLogger(OpenDocumentCommand.class);
 
     public OpenDocumentCommand(Index targetIndex) {

--- a/src/main/java/seedu/pivot/logic/parser/AddDocumentCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/AddDocumentCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.pivot.logic.parser;
 
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_CASE_PAGE;
 import static seedu.pivot.commons.core.UserMessages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.pivot.logic.parser.AddCommandParser.arePrefixesPresent;
 import static seedu.pivot.logic.parser.CliSyntax.PREFIX_NAME;
@@ -23,7 +24,7 @@ public class AddDocumentCommandParser implements Parser<AddDocumentCommand> {
      */
     @Override
     public AddDocumentCommand parse(String args) throws ParseException {
-        assert(StateManager.atCasePage()) : "Program should be at case page";
+        assert(StateManager.atCasePage()) : ASSERT_CASE_PAGE;
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_REFERENCE);

--- a/src/main/java/seedu/pivot/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/EditCommandParser.java
@@ -48,9 +48,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         case TYPE_TITLE:
             return new EditTitleCommandParser().parse(arguments);
         case TYPE_STATUS:
-
+            return new EditStatusCommandParser().parse(arguments);
         case TYPE_DOC:
-
+            return new EditDocumentCommandParser().parse(arguments);
         case TYPE_SUSPECT:
 
         case TYPE_WITNESS:

--- a/src/main/java/seedu/pivot/logic/parser/EditDocumentCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/EditDocumentCommandParser.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 
 import seedu.pivot.commons.core.index.Index;
-import seedu.pivot.logic.commands.EditCommand;
 import seedu.pivot.logic.commands.documentcommands.EditDocumentCommand;
 import seedu.pivot.logic.parser.exceptions.ParseException;
 import seedu.pivot.logic.state.StateManager;
@@ -30,13 +29,13 @@ public class EditDocumentCommandParser implements Parser<EditDocumentCommand> {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(args.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditCommand.MESSAGE_USAGE));
+                    EditDocumentCommand.MESSAGE_USAGE));
         }
         final String docIndex = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
 
         //convert docIndex to Index class
-        Index documentIndex = ParserUtil.getParsedIndex(docIndex, EditCommand.MESSAGE_USAGE);
+        Index documentIndex = ParserUtil.getParsedIndex(docIndex, EditDocumentCommand.MESSAGE_USAGE);
 
         //get case from state
         Index caseIndex = StateManager.getState();

--- a/src/main/java/seedu/pivot/logic/parser/EditDocumentCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/EditDocumentCommandParser.java
@@ -1,0 +1,80 @@
+package seedu.pivot.logic.parser;
+
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_CASE_PAGE;
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_REFERENCE_VALID;
+import static seedu.pivot.commons.core.UserMessages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.pivot.commons.core.UserMessages.MESSAGE_MISSING_PREFIX_INVALID_COMMAND;
+import static seedu.pivot.logic.parser.AddCommandParser.arePrefixesPresent;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_REFERENCE;
+import static seedu.pivot.logic.parser.PivotParser.BASIC_COMMAND_FORMAT;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+import seedu.pivot.commons.core.index.Index;
+import seedu.pivot.logic.commands.EditCommand;
+import seedu.pivot.logic.commands.documentcommands.EditDocumentCommand;
+import seedu.pivot.logic.parser.exceptions.ParseException;
+import seedu.pivot.logic.state.StateManager;
+import seedu.pivot.model.investigationcase.Reference;
+import seedu.pivot.model.investigationcase.caseperson.Name;
+
+public class EditDocumentCommandParser implements Parser<EditDocumentCommand> {
+    @Override
+    public EditDocumentCommand parse(String args) throws ParseException {
+
+        assert(StateManager.atCasePage()) : ASSERT_CASE_PAGE;
+
+        //get document index and arguments
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(args.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE));
+        }
+        final String docIndex = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+
+        //convert docIndex to Index class
+        Index documentIndex = ParserUtil.getParsedIndex(docIndex, EditCommand.MESSAGE_USAGE);
+
+        //get case from state
+        Index caseIndex = StateManager.getState();
+
+        //set up argMultimap
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(arguments, PREFIX_NAME, PREFIX_REFERENCE);
+
+        boolean noPrefix = !arePrefixesPresent(argMultimap, PREFIX_NAME)
+                && !arePrefixesPresent(argMultimap, PREFIX_REFERENCE);
+
+        //check for prefixes or command validity
+        if (noPrefix) {
+            throw new ParseException(String.format(MESSAGE_MISSING_PREFIX_INVALID_COMMAND,
+                    EditDocumentCommand.MESSAGE_USAGE));
+        } else if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditDocumentCommand.MESSAGE_USAGE));
+        }
+
+        //initialize possible Name and Reference
+        Optional<Name> name = Optional.empty();
+        Optional<Reference> reference = Optional.empty();
+
+        //update name if valid
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            name = Optional.of(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+
+        //update reference if valid
+        if (argMultimap.getValue(PREFIX_REFERENCE).isPresent()) {
+            reference = Optional.of(ParserUtil.parseReference(argMultimap.getValue(PREFIX_REFERENCE).get()));
+            assert(reference.isPresent()) : ASSERT_REFERENCE_VALID;
+            if (!reference.get().isExists()) {
+                throw new ParseException(Reference.MESSAGE_CONSTRAINTS);
+            }
+        }
+
+        return new EditDocumentCommand(caseIndex, documentIndex, name, reference);
+
+    }
+}

--- a/src/main/java/seedu/pivot/logic/parser/EditStatusCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/EditStatusCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.pivot.logic.parser;
+
+import static seedu.pivot.commons.core.DeveloperMessages.ASSERT_CASE_PAGE;
+import static seedu.pivot.commons.core.UserMessages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.pivot.logic.parser.AddCommandParser.arePrefixesPresent;
+import static seedu.pivot.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import seedu.pivot.commons.core.index.Index;
+import seedu.pivot.logic.commands.casecommands.EditStatusCommand;
+import seedu.pivot.logic.parser.exceptions.ParseException;
+import seedu.pivot.logic.state.StateManager;
+import seedu.pivot.model.investigationcase.Status;
+
+public class EditStatusCommandParser implements Parser<EditStatusCommand> {
+    @Override
+    public EditStatusCommand parse(String args) throws ParseException {
+        assert(StateManager.atCasePage()) : ASSERT_CASE_PAGE;
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STATUS);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_STATUS)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStatusCommand.MESSAGE_USAGE));
+        }
+
+        Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).orElse(""));
+        Index index = StateManager.getState();
+
+        return new EditStatusCommand(index, status);
+    }
+}

--- a/src/main/java/seedu/pivot/logic/parser/OpenCommandParser.java
+++ b/src/main/java/seedu/pivot/logic/parser/OpenCommandParser.java
@@ -29,9 +29,45 @@ public class OpenCommandParser implements Parser<OpenCommand> {
     public OpenCommand parse(String args) throws ParseException {
 
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+
+        if (StateManager.atMainPage()) {
+            return parseMainPage(matcher);
         }
+
+        if (StateManager.atCasePage()) {
+            return parseCasePage(matcher);
+        }
+
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+    }
+
+    private static OpenCommand parseMainPage(Matcher matcher) throws ParseException {
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    OpenCaseCommand.MESSAGE_USAGE));
+        }
+
+        final String openType = matcher.group("commandWord");
+        final String indexString = matcher.group("arguments");
+
+        Index index = ParserUtil.getParsedIndex(indexString, OpenCaseCommand.MESSAGE_USAGE);
+
+        switch(openType) {
+        case TYPE_CASE:
+            return new OpenCaseCommand(index);
+        case TYPE_DOC:
+            throw new ParseException(MESSAGE_INCORRECT_CASE_PAGE);
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCaseCommand.MESSAGE_USAGE));
+        }
+    }
+
+    private static OpenCommand parseCasePage(Matcher matcher) throws ParseException {
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    OpenCommand.MESSAGE_USAGE));
+        }
+
         final String openType = matcher.group("commandWord");
         final String indexString = matcher.group("arguments");
 
@@ -41,15 +77,11 @@ public class OpenCommandParser implements Parser<OpenCommand> {
         case TYPE_CASE:
             return new OpenCaseCommand(index);
         case TYPE_DOC:
-            if (StateManager.atMainPage()) {
-                throw new ParseException(MESSAGE_INCORRECT_CASE_PAGE);
-            }
             return new OpenDocumentCommand(index);
 
         default:
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
         }
-
     }
 
 }

--- a/src/test/data/JsonSerializablePivotTest/typicalPersonsPivot.json
+++ b/src/test/data/JsonSerializablePivotTest/typicalPersonsPivot.json
@@ -6,7 +6,7 @@
     "status": "COLD",
     "documents": [ {
       "name" : "name",
-      "reference" : "test1.txt"
+      "reference" : "validButShouldNotExist.txt"
     } ],
     "witnesses": [ {
       "name" : "Janice",

--- a/src/test/java/seedu/pivot/logic/commands/OpenDocumentCommandTest.java
+++ b/src/test/java/seedu/pivot/logic/commands/OpenDocumentCommandTest.java
@@ -62,6 +62,7 @@ public class OpenDocumentCommandTest {
         //get first document
         Document documentMissing = firstCase.getDocuments().get(validDocIndex.getZeroBased());
 
+
         //command to execute
         OpenDocumentCommand openDoc = new OpenDocumentCommand(validDocIndex);
 

--- a/src/test/java/seedu/pivot/logic/parser/OpenCommandParserTest.java
+++ b/src/test/java/seedu/pivot/logic/parser/OpenCommandParserTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import seedu.pivot.commons.core.index.Index;
-import seedu.pivot.logic.commands.OpenCommand;
 import seedu.pivot.logic.commands.casecommands.OpenCaseCommand;
 import seedu.pivot.logic.parser.exceptions.ParseException;
 import seedu.pivot.logic.state.StateManager;
@@ -50,7 +49,8 @@ public class OpenCommandParserTest {
 
         //No Index
         assertThrows(ParseException.class, () -> parser.parse(TYPE_CASE));
-        assertParseFailure(parser, TYPE_CASE, String.format(MESSAGE_INVALID_COMMAND_FORMAT, OpenCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, TYPE_CASE, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                OpenCaseCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -61,11 +61,11 @@ public class OpenCommandParserTest {
         //Type is wrong
         assertThrows(ParseException.class, () -> parser.parse(INVALID_TYPE + VALID_INDEX));
         assertParseFailure(parser, INVALID_TYPE + VALID_INDEX, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                OpenCommand.MESSAGE_USAGE));
+                OpenCaseCommand.MESSAGE_USAGE));
 
         //Invalid Index
         assertThrows(ParseException.class, () -> parser.parse(TYPE_CASE + INVALID_INDEX));
         assertParseFailure(parser, TYPE_CASE + INVALID_INDEX, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                OpenCommand.MESSAGE_USAGE));
+                OpenCaseCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/pivot/testutil/TypicalCases.java
+++ b/src/test/java/seedu/pivot/testutil/TypicalCases.java
@@ -33,7 +33,7 @@ public class TypicalCases {
     // The cases here are linked to the test file: typicalPersonsPivot.json
     // If the Case is modified here, it has to be modified there too.
     public static final Case ALICE_PAULINE_ASSAULT = new CaseBuilder().withTitle("Alice Pauline Assault")
-            .withDocument("name", "test1.txt")
+            .withDocument("name", "validButShouldNotExist.txt")
             .withStatus("COLD")
             .withVictims(TOM)
             .withWitnesses(JANICE)


### PR DESCRIPTION
EditStatusCommand similar to EditTitleCommand

EditDocumentCommand requires one more level of parsing in the program (Somewhat combination of add and delete parsing)
- parsing of Indexes handles by EditDocumentParser
- Command checks for document index bounds in the model as model is only passed in at Command level
- EditDocumentParser separates the checks for argMultimap to check for no prefixes. 
- Command takes in an Optional<Name> and Optional<Reference> as both fields are not a requirement at the same time.
- different EditCommand can use the new MESSAGE_MISSING_PREFIX_INVALID_COMMAND  message usage to ask user's to specify the optional field.